### PR TITLE
Create single-level UM ancillary files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,15 +56,15 @@ version: 2
 jobs:
     python2:
         environment:
-            PYTHON_VER=2
+            PYTHON_VER=2.7
         <<: *run_pytest
     python3:
         environment:
-            PYTHON_VER=3
+            PYTHON_VER=3.6
         <<: *run_pytest
     conda3:
         environment:
-            PYTHON_VER=3
+            PYTHON_VER=3.6
         <<: *run_conda
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ run_pytest: &run_pytest
                 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
                 bash conda.sh -b -p ~/miniconda
                 ~/miniconda/bin/conda config --system --add channels conda-forge
+                ~/miniconda/bin/conda config --system --add channels coecms
         - run:
             name: conda-env
             command: |
@@ -42,7 +43,8 @@ run_conda: &run_conda
             name: setup
             command: |
                 ~/miniconda/bin/conda install --yes conda-build conda-verify anaconda-client
-                ~/miniconda/bin/conda config --system --add channels coecms conda-forge
+                ~/miniconda/bin/conda config --system --add channels conda-forge
+                ~/miniconda/bin/conda config --system --add channels coecms
         - run:
             name: build
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ run_conda: &run_conda
             name: setup
             command: |
                 ~/miniconda/bin/conda install --yes conda-build conda-verify anaconda-client
-                ~/miniconda/bin/conda config --system --add channels conda-forge
+                ~/miniconda/bin/conda config --system --add channels coecms conda-forge
         - run:
             name: build
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,29 @@
 run_pytest: &run_pytest
+    docker:
+        - image: circleci/python
     steps:
         - checkout
-        - run: virtualenv venv
+        - run:
+            name: install-conda
+            command: |
+                wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
+                bash conda.sh -b -p ~/miniconda
+                ~/miniconda/bin/conda config --system --add channels conda-forge
+        - run:
+            name: conda-env
+            command: |
+                source ~/miniconda/bin/activate root
+                conda create -n coecms python=${PYTHON_VER} pytest coverage pytest-cov codecov
+                conda env update -n coecms -f conda/dev-environment.yml
         - run:
             name: install
             command: |
-                source venv/bin/activate
-                pip install pytest coverage pytest-cov codecov
+                source ~/miniconda/bin/activate coecms
                 pip install -e .[test]
         - run:
             name: test
             command: |
-                source venv/bin/activate
+                source ~/miniconda/bin/activate coecms
                 mkdir -p test-report/pytest
                 py.test --cov=coecms --cov-report xml
                 codecov
@@ -41,12 +53,12 @@ version: 2
 
 jobs:
     python2:
-        docker:
-            - image: circleci/python:2
+        environment:
+            PYTHON_VER=2
         <<: *run_pytest
     python3:
-        docker:
-            - image: circleci/python:3
+        environment:
+            PYTHON_VER=3
         <<: *run_pytest
     conda3:
         environment:

--- a/conda/dev-environment.yml
+++ b/conda/dev-environment.yml
@@ -11,3 +11,4 @@ dependencies:
     - sphinx
     - mule
     - cfunits
+    - dask

--- a/conda/dev-environment.yml
+++ b/conda/dev-environment.yml
@@ -1,6 +1,7 @@
 name: coecms
 
 channels:
+    - coecms
     - conda-forge
     - defaults
 
@@ -8,3 +9,4 @@ dependencies:
     - python
     - pytest
     - sphinx
+    - mule

--- a/conda/dev-environment.yml
+++ b/conda/dev-environment.yml
@@ -10,3 +10,4 @@ dependencies:
     - pytest
     - sphinx
     - mule
+    - cfunits

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,5 +32,5 @@ test:
 
 about:
     home: https://github.com/coecms/coecms-util
-    license: Apache
+    license: APACHE
     license_file: LICENSE

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,5 +32,5 @@ test:
 
 about:
     home: https://github.com/coecms/coecms-util
-    license: Apache 2.0
+    license: Apache
     license_file: LICENSE

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,3 +29,8 @@ test:
         - py.test
     imports:
         - coecms
+
+about:
+    home: https://github.com/coecms/coecms-util
+    license: Apache 2.0
+    license_file: LICENSE

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,6 +14,10 @@ requirements:
         - python
     run:
         - python
+        - cfunits
+        - mule
+        - xarray
+        - dask
 
 test:
     requires:

--- a/doc/api/dimension.rst
+++ b/doc/api/dimension.rst
@@ -1,0 +1,8 @@
+Dimension
+=========
+
+Misc. utilities for working with dimensions in CF conforming datasets
+
+.. autofunction:: coecms.dimension.identify_lat_lon
+
+.. autofunction:: coecms.dimension.identify_time

--- a/doc/api/um.rst
+++ b/doc/api/um.rst
@@ -1,0 +1,9 @@
+UM
+==
+
+Helpful functions for working with the UM
+
+These use the Met Office's MULE library to create UM files
+
+.. autofunction:: coecms.um.create_surface_ancillary
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,9 @@ Welcome to CLEX CMS Utility Library's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   api/dimension.rst
+
+   api/um.rst
 
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,10 @@ setup(
         cmdclass=versioneer.get_cmdclass(),
 
         install_requires = [
+            'cfunits',
+            'mule',
+            'xarray',
+            'dask',
             ],
         entry_points = {
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
             'mule',
             'xarray',
             'dask',
+            'netCDF4',
             ],
         entry_points = {
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
             'cfunits',
             'mule',
             'xarray',
-            'dask',
+            'dask[array]',
             'netCDF4',
             ],
         entry_points = {

--- a/src/coecms/dimension.py
+++ b/src/coecms/dimension.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# Copyright 2018 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from cfunits import Units
+
+def identify_lat_lon(dataarray):
+    """
+    Identify the latitude and longitude dimensions of a dataarray using CF
+    attributes
+
+    Args:
+        dataarray: Source dataarray
+
+    Returns:
+        (lat, lon): Tuple of `xarray.Dataarray` for the latitude and longitude
+            dimensions
+
+    Todo:
+        * Assumes latitude and longitude are unique
+    """
+
+    lat = None
+    lon = None
+
+    for c in dataarray.coords.values():
+        if (c.attrs.get('standard_name','') == 'latitude'
+                or Units(c.attrs.get('units','')).islatitude
+                or c.attrs.get('axis', '') == 'Y'):
+            lat = c
+
+        if (c.attrs.get('standard_name','') == 'longitude'
+                or Units(c.attrs.get('units','')).islongitude
+                or c.attrs.get('axis', '') == 'X'):
+            lon = c
+
+    if lat is None or lon is None:
+        raise Exception("Couldn't identify horizontal coordinates")
+
+    return (lat, lon)
+
+
+def identify_time(dataarray):
+    """
+    Identify the time dimension of a dataarray using CF attributes
+
+    Args:
+        dataarray: Source dataarray
+
+    Returns:
+        :obj:`xarray.Dataarray` for the time dimension
+
+    Todo:
+        * Assumes time dimension is unique
+    """
+
+    for c in dataarray.coords.values():
+        if (c.attrs.get('standard_name','') == 'time'
+                or Units(c.attrs.get('units','')).isreftime
+                or Units(c.encoding.get('units','')).isreftime
+                or c.attrs.get('axis', '') == 'T'):
+            return c
+
+    raise Exception("No time axis found")

--- a/src/coecms/dimension.py
+++ b/src/coecms/dimension.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 from cfunits import Units
 
+
 def identify_lat_lon(dataarray):
     """
     Identify the latitude and longitude dimensions of a dataarray using CF
@@ -37,13 +38,13 @@ def identify_lat_lon(dataarray):
     lon = None
 
     for c in dataarray.coords.values():
-        if (c.attrs.get('standard_name','') == 'latitude'
-                or Units(c.attrs.get('units','')).islatitude
+        if (c.attrs.get('standard_name', '') == 'latitude'
+                or Units(c.attrs.get('units', '')).islatitude
                 or c.attrs.get('axis', '') == 'Y'):
             lat = c
 
-        if (c.attrs.get('standard_name','') == 'longitude'
-                or Units(c.attrs.get('units','')).islongitude
+        if (c.attrs.get('standard_name', '') == 'longitude'
+                or Units(c.attrs.get('units', '')).islongitude
                 or c.attrs.get('axis', '') == 'X'):
             lon = c
 
@@ -68,9 +69,9 @@ def identify_time(dataarray):
     """
 
     for c in dataarray.coords.values():
-        if (c.attrs.get('standard_name','') == 'time'
-                or Units(c.attrs.get('units','')).isreftime
-                or Units(c.encoding.get('units','')).isreftime
+        if (c.attrs.get('standard_name', '') == 'time'
+                or Units(c.attrs.get('units', '')).isreftime
+                or Units(c.encoding.get('units', '')).isreftime
                 or c.attrs.get('axis', '') == 'T'):
             return c
 

--- a/src/coecms/um.py
+++ b/src/coecms/um.py
@@ -32,7 +32,8 @@ def create_surface_ancillary(input_ds, stash_map):
         stash_map: Mapping of variable name from `input_ds` to STASH code
 
     Returns:
-        :obj:`mule.AncilFile` containing ancillary file data, write out with ``.to_file()``
+        :obj:`mule.AncilFile` containing ancillary file data, write out with
+        ``.to_file()``
 
     Example:
         ::
@@ -52,7 +53,7 @@ def create_surface_ancillary(input_ds, stash_map):
     time = identify_time(input_ds)
     lat, lon = identify_lat_lon(input_ds)
 
-    tstep = (time[1] - time[0]) / numpy.timedelta64(1,'s')
+    tstep = (time[1] - time[0]) / numpy.timedelta64(1, 's')
 
     template = {
         'fixed_length_header': {
@@ -101,7 +102,7 @@ def create_surface_ancillary(input_ds, stash_map):
             'north_pole_lon': 0,
         },
         'level_dependent_constants': {
-            'dims': (1,None)
+            'dims': (1, None)
         },
     }
 
@@ -112,7 +113,8 @@ def create_surface_ancillary(input_ds, stash_map):
 
     for var, stash in stash_map.items():
         # Mask out NANs with MDI
-        var_data = xarray.where(dask.array.isnan(input_ds[var]), MDI, input_ds[var])
+        var_data = xarray.where(dask.array.isnan(
+            input_ds[var]), MDI, input_ds[var])
 
         for t in var_data[time.name]:
             field = mule.Field3.empty()
@@ -150,7 +152,8 @@ def create_surface_ancillary(input_ds, stash_map):
             field.bmdi = MDI
             field.bmks = 1.0
 
-            field.set_data_provider(mule.ArrayDataProvider(var_data.sel({time.name: t})))
+            field.set_data_provider(
+                mule.ArrayDataProvider(var_data.sel({time.name: t})))
 
             ancil.fields.append(field)
 

--- a/src/coecms/um.py
+++ b/src/coecms/um.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# Copyright 2018 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import mule
+import numpy
+import xarray
+import dask.array
+
+
+def create_um_surface_ancillary(input_ds, output_filename, stash_map):
+    """Create a surface-level UM ancillary file
+
+    Args:
+        input_ds: Source dataset/dataarray
+        output_filename: UM ancillary file to create
+        stash_map: Mapping of `input_ds` variable name to STASH code
+
+    Returns:
+        :obj:`mule.AncilFile`: Ancillary file data
+
+    Example:
+        ::
+
+            input_ds = xarray.open_mfdataset(files, engine='pynio')
+            stash_map = {'CI_GDS0_SFC': 31, 'SSTK_GDS0_SFC': 507,}
+
+            ancil = create_um_surface_ancillary(input_ds, stash_map)
+            ancil.to_file('sstice.ancil')
+
+    Todo:
+        * Assumes Gregorian calendar
+        * Assumes sub-daily frequency
+        * Does not compress output
+    """
+
+    time = input_ds.initial_time0_hours
+    lat = input_ds.g0_lat_1
+    lon = input_ds.g0_lon_2
+
+    tstep = (time[1] - time[0]) / numpy.timedelta64(1,'s')
+
+    template = {
+        'fixed_length_header': {
+            'sub_model': 1,         # Atmosphere
+            'dataset_type': 4,      # Ancillary
+            'horiz_grid_type': 0,   # Global
+            'calendar': 1,          # Gregorian
+            'grid_staggering': 6,   # EndGame
+            'time_type': 1,         # Time series
+            'model_version': 1006,  # UM 10.6
+            # Start time
+            't1_year': time.dt.year.values[0],
+            't1_month': time.dt.month.values[0],
+            't1_day': time.dt.day.values[0],
+            't1_hour': time.dt.hour.values[0],
+            't1_minute': time.dt.minute.values[0],
+            't1_second': time.dt.second.values[0],
+            # End time
+            't2_year': time.dt.year.values[-1],
+            't2_month': time.dt.month.values[-1],
+            't2_day': time.dt.day.values[-1],
+            't2_hour': time.dt.hour.values[-1],
+            't2_minute': time.dt.minute.values[-1],
+            't2_second': time.dt.second.values[-1],
+            # Frequency (must be sub-daily)
+            't3_year': 0,
+            't3_month': 0,
+            't3_day': 0,
+            't3_hour': tstep / 3600,
+            't3_minute': tstep % 3600 / 60,
+            't3_second': tstep % 60,
+        },
+        'integer_constants': {
+            'num_times': time.size,
+            'num_cols': lon.size,
+            'num_rows': lat.size,
+            'num_levels': 1,
+            'num_field_types': len(stash_map),
+        },
+        'real_constants': {
+            'start_lat': lat.values[0] + (lat.values[1] - lat.values[0])/2.0,
+            'row_spacing': lat.values[1] - lat.values[0],
+            'start_lon': lon.values[0] + (lon.values[1] - lon.values[0])/2.0,
+            'col_spacing': lon.values[1] - lon.values[0],
+            'north_pole_lat': 90,
+            'north_pole_lon': 0,
+        },
+        'level_dependent_constants': {
+            'dims': (1,None)
+        },
+    }
+
+    ancil = mule.AncilFile.from_template(template)
+
+    # UM Missing data magic value
+    MDI = -1073741824.0
+
+    for var, stash in stash_map.items():
+        # Mask out NANs with MDI
+        var_data = xarray.where(dask.array.isnan(input_ds[var]), MDI, input_ds[var])
+
+        for t in var_data.initial_time0_hours:
+            field = mule.Field3.empty()
+
+            field.lbyr = t.dt.year.values
+            field.lbmon = t.dt.month.values
+            field.lbdat = t.dt.day.values
+            field.lbhr = t.dt.hour.values
+            field.lbmin = t.dt.minute.values
+            field.lbsec = t.dt.second.values
+
+            field.lbtime = 1        # Instantaneous Gregorian calendar
+            field.lbcode = 1        # Regular Lat-Lon grid
+            field.lbhem = 0         # Global
+
+            field.lbrow = ancil.integer_constants.num_rows
+            field.lbnpt = ancil.integer_constants.num_cols
+
+            field.lbpack = 0        # No packing
+            field.lbrel = 3         # UM 8.1 or later
+            field.lbvc = 129        # Surface field
+
+            field.lbuser1 = 1       # Real data
+            field.lbuser4 = stash   # STASH code
+            field.lbuser7 = 1       # Atmosphere model
+
+            field.bplat = ancil.real_constants.north_pole_lat
+            field.bplon = ancil.real_constants.north_pole_lon
+
+            field.bdx = ancil.real_constants.col_spacing
+            field.bdy = ancil.real_constants.row_spacing
+            field.bzx = ancil.real_constants.start_lon - field.bdx / 2.0
+            field.bzy = ancil.real_constants.start_lat - field.bdy / 2.0
+
+            field.bmdi = MDI
+            field.bmks = 1.0
+
+            field.set_data_provider(mule.ArrayDataProvider(var_data.sel(initial_time0_hours = t)))
+
+            ancil.fields.append(field)
+
+    return ancil

--- a/src/coecms/um.py
+++ b/src/coecms/um.py
@@ -23,7 +23,7 @@ import xarray
 import dask.array
 
 
-def create_surface_ancillary(input_ds, output_filename, stash_map):
+def create_surface_ancillary(input_ds, stash_map):
     """Create a surface-level UM ancillary file
 
     Args:

--- a/src/coecms/um.py
+++ b/src/coecms/um.py
@@ -101,9 +101,6 @@ def create_surface_ancillary(input_ds, stash_map):
             'north_pole_lat': 90,
             'north_pole_lon': 0,
         },
-        'level_dependent_constants': {
-            'dims': (1, None)
-        },
     }
 
     ancil = mule.AncilFile.from_template(template)

--- a/src/coecms/um.py
+++ b/src/coecms/um.py
@@ -21,7 +21,7 @@ import xarray
 import dask.array
 
 
-def create_um_surface_ancillary(input_ds, output_filename, stash_map):
+def create_surface_ancillary(input_ds, output_filename, stash_map):
     """Create a surface-level UM ancillary file
 
     Args:

--- a/test/test_coecms.py
+++ b/test/test_coecms.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+
 def test_import():
     import coecms

--- a/test/test_dimension.py
+++ b/test/test_dimension.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright 2018 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from coecms.dimension import *
+
+import pytest
+import xarray
+
+
+def test_identify_lat_lon():
+    da = xarray.DataArray([[0,0],[0,0]],
+            coords=[('lat', [0,1]), ('lon', [0,1])])
+
+    # Missing CF metadata is an error
+    with pytest.raises(Exception):
+        lat, lon = identify_lat_lon(da)
+
+    # Should find units, axis or standard_name attributes
+    da.lat.attrs['units'] = 'degrees_north'
+    da.lon.attrs['axis'] = 'X'
+    lat, lon = identify_lat_lon(da)
+    assert lat.equals(da.lat)
+    assert lon.equals(da.lon)
+
+
+def test_identify_time():
+    da = xarray.DataArray([0,0],
+            coords=[('time', [0,1])])
+
+    # Missing CF metadata is an error
+    with pytest.raises(Exception):
+        time = identify_time(da)
+
+    # Units should be identified
+    da.time.attrs['units'] = 'days since 2006-01-09'
+    time = identify_time(da)
+    assert time.equals(da.time)
+
+    # Units should work with CF decoding
+    da = xarray.decode_cf(xarray.Dataset({'da': da})).da
+    time = identify_time(da)
+    assert time.equals(da.time)
+

--- a/test/test_dimension.py
+++ b/test/test_dimension.py
@@ -22,8 +22,8 @@ import xarray
 
 
 def test_identify_lat_lon():
-    da = xarray.DataArray([[0,0],[0,0]],
-            coords=[('lat', [0,1]), ('lon', [0,1])])
+    da = xarray.DataArray([[0, 0], [0, 0]],
+                          coords=[('lat', [0, 1]), ('lon', [0, 1])])
 
     # Missing CF metadata is an error
     with pytest.raises(Exception):
@@ -38,8 +38,8 @@ def test_identify_lat_lon():
 
 
 def test_identify_time():
-    da = xarray.DataArray([0,0],
-            coords=[('time', [0,1])])
+    da = xarray.DataArray([0, 0],
+                          coords=[('time', [0, 1])])
 
     # Missing CF metadata is an error
     with pytest.raises(Exception):
@@ -54,4 +54,3 @@ def test_identify_time():
     da = xarray.decode_cf(xarray.Dataset({'da': da})).da
     time = identify_time(da)
     assert time.equals(da.time)
-

--- a/test/test_um.py
+++ b/test/test_um.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright 2018 ARC Centre of Excellence for Climate Extremes
+# author: Scott Wales <scott.wales@unimelb.edu.au>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+from coecms.um import *
+
+import xarray
+import numpy
+
+def test_create_surface_ancillary():
+    da = xarray.Dataset(
+            {'sst': (['time','lat','lon'], numpy.zeros((3,3,3)))},
+            coords={
+                'time': ('time',[1,2,3],{'units':'days since 1900-01-01'}),
+                'lat': ('lat',[1,2,3],{'axis':'Y'}),
+                'lon': ('lon',[1,2,3],{'axis':'X'}),
+                })
+    da = xarray.decode_cf(da)
+
+    ancil = create_surface_ancillary(da, {'sst': 507})
+
+    # The file should pass Mule's internal checks
+    ancil.validate()

--- a/test/test_um.py
+++ b/test/test_um.py
@@ -20,14 +20,15 @@ from coecms.um import *
 import xarray
 import numpy
 
+
 def test_create_surface_ancillary():
     da = xarray.Dataset(
-            {'sst': (['time','lat','lon'], numpy.zeros((3,3,3)))},
-            coords={
-                'time': ('time',[1,2,3],{'units':'days since 1900-01-01'}),
-                'lat': ('lat',[1,2,3],{'axis':'Y'}),
-                'lon': ('lon',[1,2,3],{'axis':'X'}),
-                })
+        {'sst': (['time', 'lat', 'lon'], numpy.zeros((3, 3, 3)))},
+        coords={
+            'time': ('time', [1, 2, 3], {'units': 'days since 1900-01-01'}),
+            'lat': ('lat', [1, 2, 3], {'axis': 'Y'}),
+            'lon': ('lon', [1, 2, 3], {'axis': 'X'}),
+        })
     da = xarray.decode_cf(da)
 
     ancil = create_surface_ancillary(da, {'sst': 507})


### PR DESCRIPTION
Add `coecms.um.create_surface_ancillary()`, which can be used to create a single-level UM ancillary file from a Xarray dataset